### PR TITLE
[FIX] resource type not converted to enum

### DIFF
--- a/database/migrations/2025_08_06_051117_update_resource_replace_name_id_with_resource_type.php
+++ b/database/migrations/2025_08_06_051117_update_resource_replace_name_id_with_resource_type.php
@@ -14,9 +14,7 @@ return new class () extends Migration {
     public function up(): void
     {
         Schema::table('resources', function (Blueprint $table) {
-            if (!Schema::hasColumn('resources', 'resource_type')) {
-                $table->enum('resource_type', ResourceType::toArray())->nullable()->after('task_id');
-            }
+            $table->enum('resource_type', ResourceType::toArray())->nullable()->after('task_id');
         });
         $mapping = [
             1 => ResourceType::MATERIALS,
@@ -93,9 +91,7 @@ return new class () extends Migration {
             $table->foreign('name_id')->references('id')->on('resource_names')->onDelete('restrict');
         });
         Schema::table('resources', function (Blueprint $table) {
-            if (Schema::hasColumn('resources', 'resource_type')) {
-                $table->dropColumn('resource_type');
-            }
+            $table->dropColumn('resource_type');
         });
     }
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized a database migration to always add and remove a resource type field, ensuring consistent schema updates across environments.
  * Improves reliability during upgrades, rollbacks, fresh installs, and environment syncs by reducing intermittent migration errors.
  * No functional or UI changes for end-users; behavior remains unchanged.
  * Enhances deployment stability with no expected downtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->