### PR TITLE
PS-262 [API] Billing Receivable Endpoint

### DIFF
--- a/app/Http/Controllers/ProjectsBillingController.php
+++ b/app/Http/Controllers/ProjectsBillingController.php
@@ -13,6 +13,8 @@ use App\Http\Resources\FinalBillingProjectionResource;
 use App\Http\Resources\TotalBilledBalanceToBeBilledResource;
 use App\Services\ProjectsBillingService;
 use App\Http\Resources\ProjectedProgressBillingResource;
+use App\Http\Resources\ReceivableBillingsResource;
+use App\Models\Project;
 
 class ProjectsBillingController extends Controller
 {
@@ -85,10 +87,23 @@ class ProjectsBillingController extends Controller
             $validated['selected_year']
         );
         return FinalBillingProjectionResource::collection($result['projects'])
-        ->additional([
+            ->additional([
+                'status' => 'success',
+                'message' => 'Final billing projection loaded successfully',
+                'overall_total' => $result['overall_total'],
+            ]);
+    }
+    public function getReceivableBillings()
+    {
+        $result = Project::select('id', 'code', 'name', 'location', 'amount', 'ntp_date')
+            ->get();
+        $gross_gt = $result->sum('amount');
+        $net_gt = $gross_gt * 0.95; // sample only
+        return ReceivableBillingsResource::collection($result)->additional([
             'status' => 'success',
-            'message' => 'Final billing projection loaded successfully',
-            'overall_total' => $result['overall_total'],
+            'message' => 'Receivable billings loaded successfully',
+            'gross_gt' => $gross_gt,
+            'net_gt' => $net_gt,
         ]);
     }
 }

--- a/app/Http/Resources/ReceivableBillingsResource.php
+++ b/app/Http/Resources/ReceivableBillingsResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ReceivableBillingsResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'code' => $this->code,
+            'name' => $this->name,
+            'location' => $this->location,
+            'amount' => $this->amount,
+            'ntp_date' => $this->ntp_date?->format('Y-m-d'),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -169,11 +169,14 @@ Route::middleware('auth:api')->group(function () {
         Route::get('{project}/checklist', [ProjectController::class, 'getProjectChecklist']);
         Route::patch('{project}/checklist/update', [ProjectController::class, 'updateProjectChecklist']);
         // ───── Projects Billing ────
-        Route::get('total-billed-and-balance-to-be-billed', [ProjectsBillingController::class, 'getTotalBilledAndBalanceToBeBilled']);
-        Route::get('cumulative-billing', [ProjectsBillingController::class, 'getCumulativeBilling']);
-        Route::get('current-month-billing', [ProjectsBillingController::class, 'getCurrentMonthBilling']);
-        Route::get('projected-progress-billing', [ProjectsBillingController::class, 'getProjectedProgressBilling']);
-        Route::get('final-billing-projection', [ProjectsBillingController::class, 'getFinalBillingProjection']);
+        Route::prefix('billing')->group(function () {
+            Route::get('total-billed-and-balance-to-be-billed', [ProjectsBillingController::class, 'getTotalBilledAndBalanceToBeBilled']);
+            Route::get('cumulative', [ProjectsBillingController::class, 'getCumulativeBilling']);
+            Route::get('current-month', [ProjectsBillingController::class, 'getCurrentMonthBilling']);
+            Route::get('projected-progress', [ProjectsBillingController::class, 'getProjectedProgressBilling']);
+            Route::get('final-projection', [ProjectsBillingController::class, 'getFinalBillingProjection']);
+            Route::get('receivables', [ProjectsBillingController::class, 'getReceivableBillings']);
+        });
     });
     // ────── Attachments ──────
     Route::prefix('attachments')->group(function () {


### PR DESCRIPTION
Introduced a new ReceivableBillingsResource and a getReceivableBillings method in ProjectsBillingController to provide receivable billing data. Refactored billing-related API routes under a 'billing' prefix and added a new route for receivable billings. This change improves API organization and adds support for retrieving receivable billing information.